### PR TITLE
Add docs per backend module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,105 @@
+# Reccius
+
+Este repositorio contiene una aplicación web para la gestión de documentos, análisis y tareas de la empresa Reccius. El proyecto está principalmente construido en **PHP** para el backend y **HTML/CSS/JavaScript** para el frontend.
+
+## Tecnologías y dependencias principales
+
+- **PHP**: Lógica de servidor.
+- **MySQL**: Base de datos (se accede mediante funciones `mysqli`).
+- **JavaScript / jQuery**: Funcionalidad en el lado del cliente.
+- **DataTables**: Para tablas dinámicas en la interfaz.
+- **Chart.js**: Gráficos estadísticos.
+- **PHPMailer**: Envío de correos electrónicos.
+- **AWS SDK / Cloudflare R2**: Gestión de archivos en la nube (`pages/backend/cloud/R2_manager.php`).
+- **Bootstrap**: Estilos y componentes responsivos.
+- **jsPDF / html2canvas**: Generación de documentos PDF.
+- **GitHub Actions**: Flujo de despliegue definido en `.github/workflows/deploy-to-production.yml`.
+
+## Estructura de carpetas
+
+- `assets/` – Contiene hojas de estilo CSS, imágenes y scripts JavaScript reutilizables.
+- `documentos_publicos/` – Archivos PDF públicos almacenados en el repositorio.
+- `pages/` – Código principal de la aplicación dividido en frontend y backend.
+- `pages/backend/` – Lógica del lado del servidor: endpoints PHP, modelos y utilidades.
+- `test/` – Archivos de prueba y ejemplos estáticos.
+- `.github/` – Workflows para despliegue automático.
+
+## Principales rutas y funcionalidades
+
+A continuación se describen las rutas más relevantes dentro de `pages/`.
+
+### Autenticación y usuarios
+
+- `pages/login.html` – Formulario de inicio de sesión.
+- `pages/backend/login/loginBE.php` – Valida credenciales y crea la sesión del usuario.
+- `pages/backend/login/logoutBE.php` – Cierra la sesión.
+- `pages/crear_usuario.php` – Página para registrar un nuevo usuario.
+- `pages/asignar_roles.php` – Interfaz de asignación de roles.
+- `pages/backend/administracion_usuarios/*` – Endpoints de administración (obtención, modificación y eliminación de usuarios y roles).
+
+### Página principal
+
+- `pages/index.php` – Panel principal de la aplicación. Carga menús dinámicos y muestra accesos a las distintas áreas: usuarios, documentos, tareas, etc.
+- `pages/index_administrador.php` / `pages/index_superadmin.php` – Variaciones del panel para diferentes niveles de rol.
+
+### Gestión de tareas
+
+- `pages/listado_tareas.php` – Listado y seguimiento de tareas asignadas.
+- `pages/backend/tareas/*` – Backend para crear, modificar y listar tareas, así como envío de recordatorios.
+
+### Gestión de especificaciones y productos
+
+- `pages/documento_especificacion_producto.php` – Formulario para subir especificaciones de productos.
+- `pages/listado_especificaciones_producto.php` – Muestra todas las especificaciones cargadas.
+- `pages/backend/*especificacion*` – Scripts que guardan y procesan documentos de especificaciones en la base de datos y en la nube.
+
+### Actas y análisis de laboratorio
+
+- `pages/CALIDAD_acta_muestreo.php` – Registro de actas de muestreo.
+- `pages/CALIDAD_documento_analisisExterno.php` – Información de análisis externos.
+- `pages/CALIDAD_listado_actaLiberacion.php` – Visualización de actas de liberación generadas.
+- `pages/LABORATORIO_preparacion_solicitud.php` – Preparación de solicitudes de análisis.
+- `pages/LABORATORIO_envio_laboratorio.php` – Envío de muestras al laboratorio.
+- `pages/backend/analisis/*` – Obtención y registro de resultados de laboratorio.
+- `pages/backend/acta_liberacion/*` – Creación de actas de liberación con correlativos automáticos y generación de PDF.
+
+### Gestión de documentos
+
+- `pages/backend/documentos/obtener_tipos.php` – Devuelve la lista de documentos asociados a un producto analizado.
+- `pages/backend/documentos/eliminar_documento.php` – Elimina archivos almacenados en Cloudflare R2.
+
+### Componentes reutilizables
+
+- `pages/components/` – Fragmentos de HTML y scripts que se cargan dinámicamente en la interfaz principal. Ejemplos: gráficos de actas, listado de laboratorios, etc.
+
+### Notificaciones y correos
+
+- `pages/backend/email/envia_correoBE.php` – Envío de correos electrónicos mediante PHPMailer. Incluye funciones para envíos múltiples y con copia.
+- `pages/backend/login/notificaciones.php` – Consulta notificaciones pendientes para el usuario autenticado.
+
+### Archivos de configuración externos
+
+Algunas rutas hacen referencia a archivos de configuración fuera del repositorio (por ejemplo `/home/customw2/conexiones/config_reccius.php`). Dichos archivos definen parámetros de conexión a base de datos, credenciales de correo, etc., y no se encuentran versionados por razones de seguridad.
+
+## Flujo de despliegue
+
+El workflow `deploy-to-production.yml` permite clonar el repositorio, ajustar rutas absolutas y desplegar mediante FTP tanto a un ambiente de desarrollo como a producción.
+
+```yaml
+name: Espejo a Producción y Despliegue en Desarrollo
+on:
+  push:
+    branches: [main, ambiente_desarrollo]
+```
+
+El workflow utiliza `webfactory/ssh-agent` para autenticarse y `SamKirkland/FTP-Deploy-Action` para subir los archivos al servidor remoto. En la rama `main` también se clona un repositorio espejo (`recciuscl`) y se reemplazan rutas a dominios y carpetas.
+
+## Referencias adicionales
+
+- La carpeta `pages/backend/BACK.md` documenta la filosofía de los modelos PHP y muestra ejemplos de uso.
+- `pages/backend/cloud/R2_manager.php` contiene funciones para subir y eliminar archivos en Cloudflare R2. Maneja tipos MIME y genera URLs públicas.
+
+---
+
+Esta documentación entrega una visión global del proyecto: estructura de carpetas, tecnologías usadas y una descripción de las rutas y funcionalidades más importantes. Para detalles específicos de cada módulo se recomienda revisar directamente los archivos PHP correspondientes.
+

--- a/pages/backend/acta_liberacion/README.md
+++ b/pages/backend/acta_liberacion/README.md
@@ -1,0 +1,26 @@
+# Módulo acta_liberacion
+
+Este directorio contiene la lógica para generar y gestionar las actas de liberación de productos.
+
+## Archivos principales
+
+- `acta_liberacion_guardayfirma.php` – Guarda el acta final y registra la firma del responsable. Incluye envío de correos.
+- `carga_acta_liberacion.php` – Carga los datos de un análisis externo para elaborar la acta.
+- `carga_acta_liberacion_firmada.php` – Recibe y almacena la versión firmada en la nube.
+- `extrae_informe.php` – Genera un informe en PDF listo para el cliente.
+- `listado_actaLiberacionBE.php` – Devuelve el listado de actas emitidas.
+- `listado_productosDisponiblesBE.php` – Lista productos con análisis terminado listos para liberar.
+
+## Flujo general
+
+1. Obtener los datos de análisis y del producto.
+2. Completar la información de la acta y almacenarla en la base de datos.
+3. Firmar digitalmente y notificar por correo.
+4. Almacenar versiones finales en Cloudflare R2.
+
+### Migración a React + Deno + TypeScript
+
+- Exponer endpoints REST en Deno usando un framework como `oak`.
+- Reescribir la lógica de consultas en un módulo TypeScript que utilice un cliente MySQL para Deno.
+- El manejo de archivos y firmas puede implementarse con bibliotecas de Deno y servicios externos para PDF.
+- El frontend en React consumirá las APIs para crear y listar actas de liberación.

--- a/pages/backend/acta_muestreo/README.md
+++ b/pages/backend/acta_muestreo/README.md
@@ -1,0 +1,29 @@
+# Módulo acta_muestreo
+
+Gestiona las actas de muestreo y sus resultados de laboratorio.
+
+## Archivos principales
+
+- `genera_acta.php` – Construye una nueva acta de muestreo a partir de un análisis externo.
+- `guardar_y_firmar.php` – Almacena la acta y registra firmas digitales.
+- `ingresa_resultados.php` – Registra los resultados y adjuntos de laboratorio.
+- `listado_acta_muestreoBE.php` – Devuelve listado de actas existentes.
+- `consulta_resultados.php` – Permite consultar resultados de muestreo por ID.
+- `rechazar_acta_muestreoBE.php` – Marca un acta como rechazada.
+- `versiona_acta.php` – Genera una nueva versión manteniendo trazabilidad.
+
+Existen scripts antiguos (`old_*`) utilizados para versiones previas.
+
+## Flujo general
+
+1. Obtener datos de análisis y producto asociado.
+2. Crear la acta inicial y asignar responsables.
+3. Registrar firmas y resultados.
+4. Mantener historial de versiones y estados.
+
+### Migración a React + Deno + TypeScript
+
+- Crear una API en Deno para CRUD de actas y resultados.
+- Utilizar módulos TypeScript para manejar validaciones y control de versiones.
+- React presentará formularios dinámicos y tablas con los resultados.
+- Usar un cliente MySQL o Postgres en Deno para almacenar actas.

--- a/pages/backend/administracion_usuarios/README.md
+++ b/pages/backend/administracion_usuarios/README.md
@@ -1,0 +1,22 @@
+# Módulo administracion_usuarios
+
+Encargado de la gestión de usuarios y roles del sistema.
+
+## Archivos principales
+
+- `obtener_usuariosBE.php` – Devuelve la lista de usuarios registrados.
+- `obtener_rolesBE.php` – Lista los roles disponibles.
+- `asignar_permisosBE.php` – Asigna o actualiza el rol de un usuario.
+- `eliminar_usuarioBE.php` – Desactiva o elimina un usuario.
+
+## Flujo general
+
+1. El frontend solicita la información de usuarios o roles.
+2. Los scripts se conectan a la base de datos y devuelven datos en JSON.
+3. Se pueden actualizar permisos o eliminar registros según las acciones del administrador.
+
+### Migración a React + Deno + TypeScript
+
+- Implementar un servicio REST para usuarios y roles usando Deno.
+- Las validaciones y la autenticación se pueden centralizar en middleware TypeScript.
+- React manejará las vistas de administración consumiendo las APIs de Deno.

--- a/pages/backend/analisis/README.md
+++ b/pages/backend/analisis/README.md
@@ -1,0 +1,22 @@
+# Módulo analisis
+
+Procesa los resultados de análisis de laboratorio y gestiona revisiones.
+
+## Archivos principales
+
+- `ingresar_resultados_analisis.php` – Guarda resultados de análisis y firmas.
+- `agnadir_revision.php` – Permite agregar observaciones o revisiones a un análisis.
+- `eliminar_analisis_externoBE.php` – Elimina registros de análisis externo.
+- `Componente_laboratorios.php` – Devuelve la lista de laboratorios disponibles.
+
+## Flujo general
+
+1. El sistema recibe resultados y los vincula a actas existentes.
+2. Se registran firmas electrónicas y se actualiza el estado del análisis.
+3. Puede adjuntarse documentación adicional para cada revisión.
+
+### Migración a React + Deno + TypeScript
+
+- Crear endpoints en Deno para registrar resultados y revisiones.
+- Utilizar tipos de datos fuertes en TypeScript para evitar errores de formato.
+- React presentará formularios para la carga de resultados e historial de revisiones.

--- a/pages/backend/calidad/README.md
+++ b/pages/backend/calidad/README.md
@@ -1,0 +1,25 @@
+# Módulo calidad
+
+Maneja especificaciones de productos y documentos de calidad.
+
+## Archivos principales
+
+- `especificacion_productoBE.php` – Registra nuevas especificaciones y metadatos.
+- `documento_especificacion_productoBE.php` – Carga documentos asociados a una especificación.
+- `eliminar_especificacion_producto.php` – Borra especificaciones obsoletas.
+- `add_documentos.php` – Adjunta documentos adicionales.
+- `firma_documentoBE.php` – Gestiona la firma digital de documentos.
+- `listado_especificaciones_productoBE.php` – Devuelve todas las especificaciones registradas.
+- `listado_analisis_por_especificacion.php` – Consulta los análisis realizados por especificación.
+
+## Flujo general
+
+1. Registrar o actualizar especificaciones de producto.
+2. Subir archivos y documentos firmados a la nube.
+3. Listar y filtrar especificaciones para posteriores análisis.
+
+### Migración a React + Deno + TypeScript
+
+- Definir un API REST en Deno que manipule las especificaciones y documentos.
+- Utilizar TypeScript para validar datos antes de guardarlos en la base.
+- React puede ofrecer formularios dinámicos para subir y firmar documentos.

--- a/pages/backend/cloud/README.md
+++ b/pages/backend/cloud/README.md
@@ -1,0 +1,19 @@
+# Módulo cloud
+
+Abstrae la comunicación con el almacenamiento externo (Cloudflare R2).
+
+## Archivo principal
+
+- `R2_manager.php` – Maneja subidas y descargas de archivos a la nube. Define configuraciones de bucket y autenticación.
+
+## Flujo general
+
+1. Inicializar el cliente de R2 con las credenciales definidas en variables de entorno.
+2. Subir archivos o eliminarlos según las peticiones del resto de módulos.
+3. Generar URLs públicas para que el frontend pueda descargar los archivos.
+
+### Migración a React + Deno + TypeScript
+
+- Reescribir este manejador en TypeScript utilizando librerías compatibles con S3/R2 para Deno.
+- Centralizar la lógica de generación de URLs y manejo de permisos.
+- El frontend React consumirá dichas URLs para mostrar descargas o vistas previas.

--- a/pages/backend/components/README.md
+++ b/pages/backend/components/README.md
@@ -1,0 +1,24 @@
+# Módulo components
+
+Scripts que devuelven fragmentos reutilizables de la aplicación (estadísticas, listados, etc.).
+
+## Archivos principales
+
+- `acta.php` – Estados y conteos de actas de liberación.
+- `acumulados.php` – Totales acumulados de análisis o actas por período.
+- `analisis.php` – Datos resumidos de análisis para gráficas.
+- `especs.php` – Información de especificaciones de productos.
+- `porcentaje.php` – Cálculo de porcentajes de cumplimiento.
+- `productos.php` – Listado de productos disponibles.
+- `productos_analisados.php` – Productos analizados por fecha.
+- `promedio.php` – Cálculo de promedios de resultados de laboratorio.
+
+## Uso
+
+Estos scripts son llamados vía AJAX por el frontend para actualizar tablas y gráficos sin recargar la página.
+
+### Migración a React + Deno + TypeScript
+
+- Convertir cada script en un endpoint REST o GraphQL.
+- Centralizar las consultas a la base de datos en servicios TypeScript reutilizables.
+- En React, utilizar hooks para consumir estos datos y actualizar la interfaz.

--- a/pages/backend/documentos/README.md
+++ b/pages/backend/documentos/README.md
@@ -1,0 +1,22 @@
+# Módulo documentos
+
+Gestiona los archivos adjuntos y documentos asociados a análisis y productos.
+
+## Archivos principales
+
+- `obtener_adjuntos_analisis.php` – Devuelve adjuntos relacionados a un análisis específico.
+- `obtener_adjuntos_tipo.php` – Lista documentos opcionales según el tipo de análisis.
+- `obtener_tipos.php` – Obtiene los tipos de documentos para un producto analizado.
+- `opcionales_analisis.php` – Administra documentos opcionales requeridos por el laboratorio.
+- `eliminar_documento.php` – Elimina un archivo almacenado en la nube.
+
+## Flujo general
+
+1. Consultar la base de datos por los adjuntos requeridos.
+2. Descargar o eliminar archivos desde Cloudflare R2 mediante `cloud/R2_manager.php`.
+
+### Migración a React + Deno + TypeScript
+
+- Reescribir estos endpoints como servicios REST que devuelvan JSON.
+- Utilizar TypeScript para las validaciones y para manejar las rutas de archivos.
+- React podrá mostrar listados de adjuntos y permitir la descarga o eliminación de manera asíncrona.

--- a/pages/backend/email/README.md
+++ b/pages/backend/email/README.md
@@ -1,0 +1,19 @@
+# Módulo email
+
+Encargado del envío de notificaciones por correo.
+
+## Archivos principales
+
+- `envia_correoBE.php` – Funciones para enviar correos utilizando PHPMailer. Soporta múltiples destinatarios y archivos adjuntos.
+- `tester.php` – Script de prueba para verificar la configuración de correo.
+
+## Flujo general
+
+1. Los módulos de actas o tareas llaman a `envia_correoBE.php` para notificar a los usuarios.
+2. Se carga la librería PHPMailer desde un directorio externo y se envía el mensaje.
+
+### Migración a React + Deno + TypeScript
+
+- Utilizar un módulo SMTP para Deno (por ejemplo `denomailer`).
+- Centralizar el envío de correos en un servicio TypeScript reutilizable por los demás módulos.
+- El frontend React solo invocará los endpoints correspondientes.

--- a/pages/backend/index/README.md
+++ b/pages/backend/index/README.md
@@ -1,0 +1,20 @@
+# Módulo index
+
+Endpoints que sirven datos para las vistas principales de administradores y superadministradores.
+
+## Archivos principales
+
+- `index_administrador.php` – Recolecta datos de trazabilidad y estadísticas para la vista de administrador.
+- `index_superadminBE.php` – Similar al anterior pero con mayor nivel de detalle y acceso a registros históricos.
+
+## Flujo general
+
+1. Autenticar al usuario y verificar su rol.
+2. Consultar la base de datos por eventos recientes (trazabilidad, acciones de usuarios, etc.).
+3. Devolver la información en formato JSON para alimentar paneles y gráficos.
+
+### Migración a React + Deno + TypeScript
+
+- Implementar endpoints en Deno que devuelvan la información de trazabilidad.
+- Usar TypeScript para definir claramente las estructuras de datos (fechas, acciones, usuarios).
+- React consumirá estos endpoints para construir dashboards en tiempo real.

--- a/pages/backend/laboratorio/README.md
+++ b/pages/backend/laboratorio/README.md
@@ -1,0 +1,27 @@
+# Módulo laboratorio
+
+Gestiona las solicitudes y resultados enviados a laboratorios externos.
+
+## Archivos principales
+
+- `LABORATORIO_preparacion_solicitudBE.php` – Crea una solicitud de análisis y genera un número correlativo.
+- `cargaEsp_solicitudBE.php` – Sube documentos y especificaciones adjuntas a la solicitud.
+- `enviar_solicitud_carga.php` – Envía la solicitud a un laboratorio específico con copia a otros correos.
+- `enviar_solicitud_del_cc.php` – Elimina correos de copia en una solicitud.
+- `enviar_solicitud_externa.php` – Envía correos a laboratorios externos.
+- `firma_solicitud_externa.php` – Registra la firma digital de la solicitud.
+- `genera_version.php` – Crea una nueva versión de la solicitud.
+- `listado_solicitudesBE.php` – Listado y búsqueda de solicitudes registradas.
+
+## Flujo general
+
+1. Crear la solicitud y adjuntar documentación.
+2. Enviar la solicitud al laboratorio correspondiente.
+3. Firmar digitalmente y guardar la versión final.
+4. Consultar o buscar solicitudes previas.
+
+### Migración a React + Deno + TypeScript
+
+- Dividir las operaciones en endpoints REST para crear, enviar y versionar solicitudes.
+- Utilizar un ORM en Deno para manejar las tablas de solicitudes y laboratorios.
+- React permitirá cargar archivos y firmar de forma más amigable.

--- a/pages/backend/login/README.md
+++ b/pages/backend/login/README.md
@@ -1,0 +1,22 @@
+# Módulo login
+
+Controla la autenticación de usuarios y la gestión de sesiones.
+
+## Archivos principales
+
+- `loginBE.php` – Valida las credenciales, crea la sesión y establece tokens CSRF.
+- `logoutBE.php` – Cierra la sesión activa del usuario.
+- `notificaciones.php` – Devuelve notificaciones pendientes tras el inicio de sesión.
+
+## Flujo general
+
+1. El usuario envía sus credenciales desde el formulario de `pages/login.html`.
+2. `loginBE.php` valida las credenciales con la base de datos y crea la sesión.
+3. Posteriormente se consultan notificaciones pendientes.
+4. `logoutBE.php` destruye la sesión cuando el usuario decide salir.
+
+### Migración a React + Deno + TypeScript
+
+- Implementar autenticación basada en tokens JWT generados por un servicio Deno.
+- Utilizar middlewares en TypeScript para validar sesiones y permisos.
+- React gestionará el estado de autenticación utilizando contextos o librerías como Redux.

--- a/pages/backend/otros/README.md
+++ b/pages/backend/otros/README.md
@@ -1,0 +1,18 @@
+# Módulo otros
+
+Contiene utilidades y clases auxiliares utilizadas por distintos módulos.
+
+## Archivos principales
+
+- `laboratorio.php` – Clase `Laboratorio` para consultar y gestionar laboratorios (incluye correos en copia).
+- `feriados_chile.php` – Funciones para determinar feriados nacionales (útil para cálculos de plazos).
+- `convertir_imagenes.php` – Utilidad para convertir imágenes a PDF o ajustar su tamaño.
+
+## Uso
+
+Estos archivos son referenciados por otros módulos como `laboratorio/` y `tareas/` para funciones comunes.
+
+### Migración a React + Deno + TypeScript
+
+- Reescribir las clases y utilidades en módulos TypeScript.
+- Exponer funciones compartidas a través de paquetes internos que pueda consumir la API y el frontend.

--- a/pages/backend/roles/README.md
+++ b/pages/backend/roles/README.md
@@ -1,0 +1,12 @@
+# Módulo roles
+
+Proporciona endpoints para obtener la lista de roles disponibles en el sistema.
+
+## Archivo principal
+
+- `rolesBE.php` – Devuelve los roles registrados en la base de datos en formato JSON.
+
+### Migración a React + Deno + TypeScript
+
+- Implementar un servicio en Deno que exponga los roles y permita su mantenimiento.
+- TypeScript facilitará la definición de permisos y la interacción con la base de datos.

--- a/pages/backend/tareas/README.md
+++ b/pages/backend/tareas/README.md
@@ -1,0 +1,23 @@
+# Módulo tareas
+
+Administra la creación y seguimiento de tareas asignadas a los usuarios.
+
+## Archivos principales
+
+- `tareasBE.php` – Endpoint principal para crear o actualizar tareas.
+- `listado_tareasBE.php` – Devuelve el listado completo de tareas para el usuario autenticado.
+- `Componente_tareasBE.php` – Fragmento utilizado en la página principal para mostrar tareas resumidas.
+- `cambiar_usuarioBE.php` – Permite reasignar una tarea a otro usuario.
+- `recordatorioBE.php` – Envía recordatorios de tareas pendientes por correo.
+
+## Flujo general
+
+1. Crear o modificar tareas mediante formularios del frontend.
+2. Enviar notificaciones por correo cuando corresponda.
+3. Listar y filtrar tareas por usuario o estado.
+
+### Migración a React + Deno + TypeScript
+
+- Definir un API REST para tareas que permita operaciones CRUD completas.
+- Implementar websockets o suscripción para actualizaciones en tiempo real si es necesario.
+- React puede utilizar componentes de tabla para mostrar el seguimiento.

--- a/pages/backend/usuario/README.md
+++ b/pages/backend/usuario/README.md
@@ -1,0 +1,23 @@
+# Módulo usuario
+
+Manejo de creación y modificación de perfiles de usuario.
+
+## Archivos principales
+
+- `crear_usuarioBE.php` – Registra un nuevo usuario y envía correo de bienvenida.
+- `modificar_perfilBE.php` – Actualiza datos personales y cargo.
+- `modifica_perfilFETCH.php` – Obtiene información del usuario para precargar formularios.
+- `obtener_usuarioBE.php` – Devuelve el detalle de un usuario por su nombre o ID.
+- `restablece-contrasenaBE.php` – Envía correo para restablecer la contraseña.
+
+## Flujo general
+
+1. El administrador registra usuarios y define su rol inicial.
+2. Los usuarios pueden modificar su perfil y restablecer contraseñas.
+3. Se envían correos de confirmación y notificaciones.
+
+### Migración a React + Deno + TypeScript
+
+- Implementar servicios REST en Deno para crear y actualizar usuarios.
+- Manejar el envío de correos desde un módulo centralizado (ver `email/`).
+- React gestionará los formularios y validaciones de manera más dinámica.


### PR DESCRIPTION
## Summary
- add detailed README documents for each folder in `pages/backend`

## Testing
- `php -l pages/index.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6847b6b8d944832a8d2a7f7b744dceda