### PR TITLE
Restringir acceso a botones de eliminación solo para isumonte

### DIFF
--- a/pages/CALIDAD_listado_productosDisponibles.php
+++ b/pages/CALIDAD_listado_productosDisponibles.php
@@ -137,6 +137,8 @@ while ($row = mysqli_fetch_assoc($result)) {
 
 </html>
 <script>
+    var usuarioActual = "<?php echo $_SESSION['usuario']; ?>";
+    
     function filtrar_listado(valor, filtro) {
         var table = $('#listado').DataTable();
         
@@ -694,7 +696,10 @@ while ($row = mysqli_fetch_assoc($result)) {
                             <td>${fecha_carga.split('-').reverse().join('/')}</td>
                             <td>
                                 <a href="${url}" target="_blank">Ver</a>/
-                                <button class="btn btn-primary" onclick="eliminarAdjunto(${id}, ${id_productos_analizados})">Eliminar</button>
+                                ${(usuarioActual === 'isumonte@reccius.cl' || usuarioActual === 'isumonte') ? 
+                                    '<button class="btn btn-primary" onclick="eliminarAdjunto(' + id + ', ' + id_productos_analizados + ')">Eliminar</button>' : 
+                                    ''
+                                }
                             </td>
                         </tr>`
                     });

--- a/pages/LABORATORIO_listado_solicitudes.php
+++ b/pages/LABORATORIO_listado_solicitudes.php
@@ -337,7 +337,10 @@ if (!isset($_SESSION['usuario']) || empty($_SESSION['usuario'])) {
             if ( d.estado === "Pendiente liberación productos") {
             acciones += `<button class="accion-btn ingControl" title="Solicitud Liberacion" type="button" id="${d.id_analisisExterno}" name="Liberacion" onclick="botones(this.id, this.name, \'laboratorio\')"><i class="fas fa-search"></i> Emitir Acta de Liberación</button><a> </a>`;
             }
-            acciones += `<button class="accion-btn ingControl" title="Eliminar Solicitud" type="button" id="${d.id_analisisExterno}" name="eliminar_analisis_externo" style="background-color: red; color: white;" onclick="botones_interno(this.id, this.name, 'laboratorio')"> <i class="fas fa-trash"></i> Eliminar Análisis Externo</button><a> </a>`;
+            // Solo mostrar botón de eliminación para isumonte o isumonte@reccius.cl
+            if ('<?php echo $_SESSION['usuario']; ?>' === 'isumonte@reccius.cl' || '<?php echo $_SESSION['usuario']; ?>' === 'isumonte') {
+                acciones += `<button class="accion-btn ingControl" title="Eliminar Solicitud" type="button" id="${d.id_analisisExterno}" name="eliminar_analisis_externo" style="background-color: red; color: white;" onclick="botones_interno(this.id, this.name, 'laboratorio')"> <i class="fas fa-trash"></i> Eliminar Análisis Externo</button><a> </a>`;
+            }
             acciones += '</td></tr></table>';
 
             return acciones;

--- a/pages/backend/analisis/eliminar_analisis_externoBE.php
+++ b/pages/backend/analisis/eliminar_analisis_externoBE.php
@@ -6,6 +6,12 @@ if (!isset($_SESSION['usuario']) || empty($_SESSION['usuario'])) {
     header("Location: https://customware.cl/reccius/pages/login.html");
     exit;
 }
+
+// Verificar que solo isumonte o isumonte@reccius.cl pueda ejecutar esta operación
+if ($_SESSION['usuario'] !== 'isumonte@reccius.cl' && $_SESSION['usuario'] !== 'isumonte') {
+    echo json_encode(['error' => 'No tienes permisos para realizar esta operación.']);
+    exit;
+}
 // Comprobar si el ID fue enviado por POST
 if (!isset($_POST['id_analisisExterno'])) {
     echo json_encode(['error' => 'No se proporcionó el ID necesario.']);

--- a/pages/backend/calidad/eliminar_especificacion_producto.php
+++ b/pages/backend/calidad/eliminar_especificacion_producto.php
@@ -6,6 +6,12 @@ if (!isset($_SESSION['usuario']) || empty($_SESSION['usuario'])) {
     header("Location: https://customware.cl/reccius/pages/login.html");
     exit;
 }
+
+// Verificar que solo isumonte o isumonte@reccius.cl pueda ejecutar esta operación
+if ($_SESSION['usuario'] !== 'isumonte@reccius.cl' && $_SESSION['usuario'] !== 'isumonte') {
+    echo json_encode(['error' => 'No tienes permisos para realizar esta operación.']);
+    exit;
+}
 // Comprobar si el ID fue enviado por POST
 if (!isset($_POST['id_especificacionProducto'])) {
     echo json_encode(['error' => 'No se proporcionó el ID necesario.']);

--- a/pages/backend/documentos/eliminar_documento.php
+++ b/pages/backend/documentos/eliminar_documento.php
@@ -9,6 +9,12 @@ if (!isset($_SESSION['usuario']) || empty($_SESSION['usuario'])) {
     exit;
 }
 
+// Verificar que solo isumonte o isumonte@reccius.cl pueda ejecutar esta operación
+if ($_SESSION['usuario'] !== 'isumonte@reccius.cl' && $_SESSION['usuario'] !== 'isumonte') {
+    echo json_encode(['exito' => false, 'mensaje' => 'No tienes permisos para realizar esta operación.']);
+    exit;
+}
+
 header('Content-Type: application/json');
 
 // Validar que se haya proporcionado un ID de documento

--- a/pages/listado_especificaciones_producto.php
+++ b/pages/listado_especificaciones_producto.php
@@ -253,7 +253,10 @@ if (!isset($_SESSION['usuario']) || empty($_SESSION['usuario'])) {
     if (d.estado === 'Vigente') {
         acciones += '<button class="accion-btn ingControl" title="Generar Solicitud de Análisis externo" id="' + d.id_especificacion + '" name="prepararSolicitud" onclick="botones({analisisExterno:0, especificacion:this.id}, this.name, \'especificacion\')"><i class="fas fa-vial"></i> Generar Solicitud de análisis externo</button><a> </a>';
     }
-    acciones += '<button class="accion-btn ingControl" title="Eliminar Especificación de Producto" id="' + d.id_especificacion + '" name="eliminar_especificacion_producto" style="background-color: red; color: white;" onclick="botones_interno(this.id, this.name, \'laboratorio\')"><i class="fas fa-trash"></i> Eliminar Especificación de Producto</button><a> </a>';
+    // Solo mostrar botón de eliminación para isumonte o isumonte@reccius.cl
+    if ('<?php echo $_SESSION['usuario']; ?>' === 'isumonte@reccius.cl' || '<?php echo $_SESSION['usuario']; ?>' === 'isumonte') {
+        acciones += '<button class="accion-btn ingControl" title="Eliminar Especificación de Producto" id="' + d.id_especificacion + '" name="eliminar_especificacion_producto" style="background-color: red; color: white;" onclick="botones_interno(this.id, this.name, \'laboratorio\')"><i class="fas fa-trash"></i> Eliminar Especificación de Producto</button><a> </a>';
+    }
     acciones += '</td></tr></table>';
     return acciones;
 }


### PR DESCRIPTION
## Resumen

Implementación de filtro hardcodeado para restringir el acceso a los botones de eliminación únicamente a la usuaria `isumonte` (compatible con ambos formatos: `isumonte` y `isumonte@reccius.cl`).

### Funcionalidades afectadas:
- ✅ **Eliminar Especificación de Producto** (listado de especificaciones)
- ✅ **Eliminar Análisis Externo** (listado de solicitudes de análisis)  
- ✅ **Eliminar documentos** (productos en cuarentena y liberados)

### Cambios implementados:

#### Frontend (UI):
- `pages/listado_especificaciones_producto.php:257` - Botón "Eliminar Especificación de Producto"
- `pages/LABORATORIO_listado_solicitudes.php:341` - Botón "Eliminar Análisis Externo"
- `pages/CALIDAD_listado_productosDisponibles.php:699` - Botón "Eliminar" documentos

#### Backend (Seguridad):
- `pages/backend/calidad/eliminar_especificacion_producto.php:11` - Validación de permisos
- `pages/backend/analisis/eliminar_analisis_externoBE.php:11` - Validación de permisos  
- `pages/backend/documentos/eliminar_documento.php:13` - Validación de permisos

### Implementación de seguridad:

**Nivel 1 - Frontend:** Los botones solo se muestran si el usuario es `isumonte` o `isumonte@reccius.cl`

**Nivel 2 - Backend:** Verificación adicional en cada endpoint para mayor seguridad

### Compatibilidad:
- ✅ Funciona con formato de usuario: `isumonte`
- ✅ Funciona con formato de correo: `isumonte@reccius.cl`

## Test plan

- [ ] Verificar que los botones de eliminación NO se muestren para usuarios diferentes a isumonte
- [ ] Verificar que los botones SÍ se muestren para usuario isumonte/isumonte@reccius.cl
- [ ] Probar que las validaciones de backend rechacen usuarios no autorizados
- [ ] Confirmar que isumonte puede ejecutar las eliminaciones correctamente

🤖 Generated with [Claude Code](https://claude.ai/code)